### PR TITLE
Add Least-Square harmonic analysis method (for muiltiband-noise branch)

### DIFF
--- a/common.h
+++ b/common.h
@@ -47,7 +47,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 #define max(a, b) ((a) > (b) ? (a) : (b))
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
-inline void** malloc2d(size_t m, size_t n, size_t size) {
+static inline void** malloc2d(size_t m, size_t n, size_t size) {
   void** ret = calloc(m, sizeof(void*));
   for(size_t i = 0; i < m; i++)
     ret[i] = calloc(n, size);
@@ -55,7 +55,7 @@ inline void** malloc2d(size_t m, size_t n, size_t size) {
 }
 
 #define copy2d(src, m, n, size) copy2d_((void**)src, m, n, size)
-inline void** copy2d_(void** src, size_t m, size_t n, size_t size) {
+static inline void** copy2d_(void** src, size_t m, size_t n, size_t size) {
   void** ret = malloc2d(m, n, size);
   for(size_t i = 0; i < m; i ++)
     memcpy(ret[i], src[i], n * size);
@@ -63,13 +63,13 @@ inline void** copy2d_(void** src, size_t m, size_t n, size_t size) {
 }
 
 #define free2d(ptr, m) free2d_((void**)(ptr), m)
-inline void free2d_(void** ptr, size_t m) {
+static inline void free2d_(void** ptr, size_t m) {
   for(size_t i = 0; i < m; i ++)
     free(ptr[i]);
   free(ptr);
 }
 
-inline FP_TYPE* fetch_frame(FP_TYPE* x, int nx, int center, int nf) {
+static inline FP_TYPE* fetch_frame(FP_TYPE* x, int nx, int center, int nf) {
   FP_TYPE* y = calloc(nf, sizeof(FP_TYPE));
   for(int i = 0; i < nf; i ++) {
     int isrc = center + i - nf / 2;
@@ -79,4 +79,3 @@ inline FP_TYPE* fetch_frame(FP_TYPE* x, int nx, int center, int nf) {
 }
 
 #endif
-

--- a/common.h
+++ b/common.h
@@ -36,7 +36,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 #include <string.h>
 #include <math.h>
 #include <unistd.h>
-#define FP_TYPE double
+#ifndef FP_TYPE
+  #define FP_TYPE double
+#endif
 
 #ifndef M_PI
   #define M_PI 3.1415926535897932385

--- a/external/fastapprox/fasttrig.h
+++ b/external/fastapprox/fasttrig.h
@@ -53,12 +53,12 @@
 // inaccurate for |x| >> 1000
 //
 // WARNING: fastsinfull, fastcosfull, and fasttanfull can be slower than
-// libc calls on older machines (!) and on newer machines are only 
+// libc calls on older machines (!) and on newer machines are only
 // slighly faster.  however:
 //   * vectorized versions are competitive
 //   * faster full versions are competitive
 
-inline float
+static inline float
 fastsin (float x)
 {
   static const float fouroverpi = 1.2732395447351627f;
@@ -82,7 +82,7 @@ fastsin (float x)
   return q * qpprox + qpproxsq * (p.f + qpproxsq * (r.f + qpproxsq * s.f));
 }
 
-inline float
+static inline float
 fastersin (float x)
 {
   static const float fouroverpi = 1.2732395447351627f;
@@ -101,7 +101,7 @@ fastersin (float x)
   return qpprox * (q + p.f * qpprox);
 }
 
-inline float
+static inline float
 fastsinfull (float x)
 {
   static const float twopi = 6.2831853071795865f;
@@ -112,7 +112,7 @@ fastsinfull (float x)
   return fastsin ((half + k) * twopi - x);
 }
 
-inline float
+static inline float
 fastersinfull (float x)
 {
   static const float twopi = 6.2831853071795865f;
@@ -123,7 +123,7 @@ fastersinfull (float x)
   return fastersin ((half + k) * twopi - x);
 }
 
-inline float
+static inline float
 fastcos (float x)
 {
   static const float halfpi = 1.5707963267948966f;
@@ -132,7 +132,7 @@ fastcos (float x)
   return fastsin (x + offset);
 }
 
-inline float
+static inline float
 fastercos (float x)
 {
   static const float twooverpi = 0.63661977236758134f;
@@ -146,34 +146,34 @@ fastercos (float x)
   return qpprox + p * qpprox * (1.0f - qpprox * qpprox);
 }
 
-inline float
+static inline float
 fastcosfull (float x)
 {
   static const float halfpi = 1.5707963267948966f;
   return fastsinfull (x + halfpi);
 }
 
-inline float
+static inline float
 fastercosfull (float x)
 {
   static const float halfpi = 1.5707963267948966f;
   return fastersinfull (x + halfpi);
 }
 
-inline float
+static inline float
 fasttan (float x)
 {
   static const float halfpi = 1.5707963267948966f;
   return fastsin (x) / fastsin (x + halfpi);
 }
 
-inline float
+static inline float
 fastertan (float x)
 {
   return fastersin (x) / fastercos (x);
 }
 
-inline float
+static inline float
 fasttanfull (float x)
 {
   static const float twopi = 6.2831853071795865f;
@@ -186,7 +186,7 @@ fasttanfull (float x)
   return fastsin (xnew) / fastcos (xnew);
 }
 
-inline float
+static inline float
 fastertanfull (float x)
 {
   static const float twopi = 6.2831853071795865f;
@@ -201,7 +201,7 @@ fastertanfull (float x)
 
 #ifdef __SSE2__
 
-inline v4sf
+static inline v4sf
 vfastsin (const v4sf x)
 {
   const v4sf fouroverpi = v4sfl (1.2732395447351627f);
@@ -223,7 +223,7 @@ vfastsin (const v4sf x)
   return q * qpprox + vy.f;
 }
 
-inline v4sf
+static inline v4sf
 vfastersin (const v4sf x)
 {
   const v4sf fouroverpi = v4sfl (1.2732395447351627f);
@@ -243,7 +243,7 @@ vfastersin (const v4sf x)
   return qpprox * (q + p.f * qpprox);
 }
 
-inline v4sf
+static inline v4sf
 vfastsinfull (const v4sf x)
 {
   const v4sf twopi = v4sfl (6.2831853071795865f);
@@ -258,7 +258,7 @@ vfastsinfull (const v4sf x)
   return vfastsin ((half + v4si_to_v4sf (k)) * twopi - x);
 }
 
-inline v4sf
+static inline v4sf
 vfastersinfull (const v4sf x)
 {
   const v4sf twopi = v4sfl (6.2831853071795865f);
@@ -273,7 +273,7 @@ vfastersinfull (const v4sf x)
   return vfastersin ((half + v4si_to_v4sf (k)) * twopi - x);
 }
 
-inline v4sf
+static inline v4sf
 vfastcos (const v4sf x)
 {
   const v4sf halfpi = v4sfl (1.5707963267948966f);
@@ -284,7 +284,7 @@ vfastcos (const v4sf x)
   return vfastsin (x + offset);
 }
 
-inline v4sf
+static inline v4sf
 vfastercos (v4sf x)
 {
   const v4sf twooverpi = v4sfl (0.63661977236758134f);
@@ -296,34 +296,34 @@ vfastercos (v4sf x)
   return qpprox + p * qpprox * (v4sfl (1.0f) - qpprox * qpprox);
 }
 
-inline v4sf
+static inline v4sf
 vfastcosfull (const v4sf x)
 {
   const v4sf halfpi = v4sfl (1.5707963267948966f);
   return vfastsinfull (x + halfpi);
 }
 
-inline v4sf
+static inline v4sf
 vfastercosfull (const v4sf x)
 {
   const v4sf halfpi = v4sfl (1.5707963267948966f);
   return vfastersinfull (x + halfpi);
 }
 
-inline v4sf
+static inline v4sf
 vfasttan (const v4sf x)
 {
   const v4sf halfpi = v4sfl (1.5707963267948966f);
   return vfastsin (x) / vfastsin (x + halfpi);
 }
 
-inline v4sf
+static inline v4sf
 vfastertan (const v4sf x)
 {
   return vfastersin (x) / vfastercos (x);
 }
 
-inline v4sf
+static inline v4sf
 vfasttanfull (const v4sf x)
 {
   const v4sf twopi = v4sfl (6.2831853071795865f);
@@ -339,7 +339,7 @@ vfasttanfull (const v4sf x)
   return vfastsin (xnew) / vfastcos (xnew);
 }
 
-inline v4sf
+static inline v4sf
 vfastertanfull (const v4sf x)
 {
   const v4sf twopi = v4sfl (6.2831853071795865f);

--- a/external/matlabfunctions.c
+++ b/external/matlabfunctions.c
@@ -28,11 +28,11 @@
 #define true  1
 typedef int bool;
 
-inline int MyMax(int x, int y) {
+static inline int MyMax(int x, int y) {
   return x > y ? x : y;
 }
 
-inline int MyMin(int x, int y) {
+static inline int MyMin(int x, int y) {
   return x < y ? x : y;
 }
 

--- a/llsm.c
+++ b/llsm.c
@@ -63,6 +63,7 @@ llsm_parameters llsm_init(int nnosband) {
   ret.a_nosbandf = calloc(nnosband - 1, sizeof(FP_TYPE));
   ret.a_nosbandf[0] = 2000;
   ret.a_method = qhm;
+  ret.a_qhmlsmethod = 'Q'; // use ?gels
   ret.a_maxairiter = 16;
   ret.a_maxqhmiter = 4;
   ret.a_targetsrer = 30.0;

--- a/llsm.c
+++ b/llsm.c
@@ -547,13 +547,18 @@ llsm* llsm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f
             rf0[j] = avg_f0;
         }
     }
-  }
-  else if(param.a_hamethod == LLSM_HAMETHOD_QHM) {
+  } else if(param.a_hamethod == LLSM_HAMETHOD_QHM) {
+    #ifdef ENABLE_QHM
     qhm_air(param, x, nx, fs, rf0, nf0, "blackman");
     qhm_analyze(param, x, nx, fs, rf0, nf0, model -> sinu, "blackman");
-  }
-  else {
-    fprintf(stderr, "Invalid parameter 'a_hamethod'. Aborting...\n");
+    #else
+    fprintf(stderr, "\nThis libllsm doesn't support LLSM_HAMETHOD_QHM.\n\
+Please rebuild with 'make ENABLE_QHM=1'.\n\
+Aborting....\n");
+    abort();
+    #endif
+  } else {
+    fprintf(stderr, "Invalid 'a_hamethod'. Aborting...\n");
     abort();
   }
 
@@ -865,4 +870,15 @@ FP_TYPE* llsm_synthesize(llsm_parameters param, llsm* model, int* ny) {
 
   free(ola_window);
   return y_sin;
+}
+
+int is_hamethod_supported(int method) {
+  if(method == LLSM_HAMETHOD_QFFT)
+    return 1;
+  #ifdef ENABLE_QHM
+  else if(method == LLSM_HAMETHOD_QHM)
+    return 1;
+  #endif
+  else
+    return 0;
 }

--- a/llsm.c
+++ b/llsm.c
@@ -62,8 +62,8 @@ llsm_parameters llsm_init(int nnosband) {
   ret.a_nnosband = nnosband;
   ret.a_nosbandf = calloc(nnosband - 1, sizeof(FP_TYPE));
   ret.a_nosbandf[0] = 2000;
-  ret.a_method = qfft;
-  ret.a_qhmlsmethod = 'Q'; // use ?gels
+  ret.a_hamethod = LLSM_HAMETHOD_QFFT;
+  ret.a_qhmlsmethod = QHM_LSMETHOD_QR;
   ret.a_maxairiter = 16;
   ret.a_maxqhmiter = 4;
   ret.a_maxqhmcorr = 20.0;
@@ -529,7 +529,7 @@ llsm* llsm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f
   FP_TYPE* tmpampl = calloc(nf0, sizeof(FP_TYPE));
   FP_TYPE* tmpphse = calloc(nf0, sizeof(FP_TYPE));
 
-  if(param.a_method == qfft) {
+  if(param.a_hamethod == LLSM_HAMETHOD_QFFT) {
     for(int i = 0; i < param.a_nhar; i ++) {
       find_harmonic_trajectory(param, spectrogram, phasegram, nfft, fs, rf0, nf0, i + 1, tmpfreq, tmpampl, tmpphse);
       for(int j = 0; j < nf0; j ++) {
@@ -548,12 +548,12 @@ llsm* llsm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f
         }
     }
   }
-  else if(param.a_method == qhm) {
+  else if(param.a_hamethod == LLSM_HAMETHOD_QHM) {
     qhm_air(param, x, nx, fs, rf0, nf0, "blackman");
     qhm_analyze(param, x, nx, fs, rf0, nf0, model -> sinu, "blackman");
   }
   else {
-    fprintf(stderr, "Invalid parameter->a_method. Aborting...\n");
+    fprintf(stderr, "Invalid parameter 'a_hamethod'. Aborting...\n");
     abort();
   }
 
@@ -580,7 +580,7 @@ llsm* llsm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f
   // C7
   for(int i = 0; i < nx; i ++)
     resynth[i] = x[i] - resynth[i];
-  wavwrite(resynth, nx, fs, 16, "noise.wav");
+  // wavwrite(resynth, nx, fs, 16, "noise.wav");
 
   // C21
   FP_TYPE** noise_spectrogram = (FP_TYPE**)malloc2d(nf0, nfft / 2, sizeof(FP_TYPE));

--- a/llsm.c
+++ b/llsm.c
@@ -62,11 +62,10 @@ llsm_parameters llsm_init(int nnosband) {
   ret.a_nnosband = nnosband;
   ret.a_nosbandf = calloc(nnosband - 1, sizeof(FP_TYPE));
   ret.a_nosbandf[0] = 2000;
-  ret.a_method = qhm;
+  ret.a_method = qfft;
   ret.a_qhmlsmethod = 'Q'; // use ?gels
   ret.a_maxairiter = 16;
   ret.a_maxqhmiter = 4;
-  ret.a_targetsrer = 30.0;
   ret.a_maxqhmcorr = 20.0;
   for(int i = 1; i < nnosband - 1; i ++) ret.a_nosbandf[i] = ret.a_nosbandf[i - 1] * 2.0;
   ret.s_fs = 0;

--- a/llsm.h
+++ b/llsm.h
@@ -113,8 +113,8 @@ typedef struct {
 */
 
 typedef enum {
-  qfft = 0,
-  qhm
+  qfft = 0, // use fft spectrum peak picking on quasi-harmonic analysis
+  qhm // use Least-Square
 } llsm_harmonic_analysis_method;
 
 typedef struct {
@@ -130,12 +130,11 @@ typedef struct {
   FP_TYPE* a_nosbandf;  // upper frequency of each noise band
   int a_nnosband;       // number of noise bands
 
-  llsm_harmonic_analysis_method a_method;
-  int a_qhmlsmethod;
-  int a_maxairiter;
-  int a_maxqhmiter;
-  FP_TYPE a_maxqhmcorr;
-  FP_TYPE a_targetsrer;
+  llsm_harmonic_analysis_method a_method; // method of quasi-harmonic analysis, qfft by default
+  char a_qhmlsmethod; // method of LS. 'Q' remains QR/LR(faster). 'S' remains SVD(better quality, very slow).
+  int a_maxairiter;  // maximum number of air iteration, 16 by default
+  int a_maxqhmiter; // maximum number of qhm iteration, 4 by default
+  FP_TYPE a_maxqhmcorr; // maximum frequency correction per iteration(in Hz)
 
   // params for synthesis
   int s_fs;             // sampling frequency

--- a/llsm.h
+++ b/llsm.h
@@ -131,6 +131,7 @@ typedef struct {
   int a_nnosband;       // number of noise bands
 
   llsm_harmonic_analysis_method a_method;
+  int a_qhmlsmethod;
   int a_maxairiter;
   int a_maxqhmiter;
   FP_TYPE a_maxqhmcorr;

--- a/llsm.h
+++ b/llsm.h
@@ -50,7 +50,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 #ifndef LLSM
 #define LLSM
 
-#define FP_TYPE double
+#ifndef FP_TYPE
+  #define FP_TYPE double
+#endif
 
 /*
   llsm_sinparam: model parameters for sinusoidal signals

--- a/llsm.h
+++ b/llsm.h
@@ -153,4 +153,9 @@ llsm* llsm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f
 FP_TYPE* llsm_synthesize(llsm_parameters param, llsm* model, int* ny);
 void llsm_delete(llsm* model);
 
+/*
+  check if a given harmonic analysis method is supported.
+*/
+int is_hamethod_supported(int method);
+
 #endif

--- a/llsm.h
+++ b/llsm.h
@@ -37,7 +37,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
     nx/ny/... length of x/y/...
     f0        fundamental frequency
     fs        sampling frequency
-  
+
   Memory Structure for FP_TYPE**
     Unless otherwise specified, the first dimension is time and the second is frequency.
     For example,
@@ -68,7 +68,7 @@ typedef struct {
 */
 typedef struct {
   llsm_sinparam* eenv;  // sinusoidal parameters for noise energy envelope
-  FP_TYPE* emin;        // minimum noise energy  
+  FP_TYPE* emin;        // minimum noise energy
 } llsm_echannel;
 
 /*
@@ -84,7 +84,7 @@ typedef struct {
   FP_TYPE mvf;          // maximum voiced frequency
   FP_TYPE nosf;         // upper bound of noise frequency
   FP_TYPE thop;         // hop size in seconds
-  
+
   FP_TYPE* nosbandf;    // upper frequency of each noise band, excluding nosf; example: [2000, 4000, 8000]
   int nnosband;         // number of noise bands
 } llsm_conf;
@@ -109,6 +109,12 @@ typedef struct {
     paramters (i.e. what we get after analyzing the speech); the later is a set of configurations for
     analysis/synthesis processes. We name so to make it consistent with libpyin (see pyin_paramters).
 */
+
+typedef enum {
+  qfft = 0,
+  qhm
+} llsm_harmonic_analysis_method;
+
 typedef struct {
   // params for analysis
   int a_nhop;           // hop size in samples
@@ -121,6 +127,12 @@ typedef struct {
   FP_TYPE a_nosf;       // maximum noise frequency
   FP_TYPE* a_nosbandf;  // upper frequency of each noise band
   int a_nnosband;       // number of noise bands
+
+  llsm_harmonic_analysis_method a_method;
+  int a_maxairiter;
+  int a_maxqhmiter;
+  FP_TYPE a_maxqhmcorr;
+  FP_TYPE a_targetsrer;
 
   // params for synthesis
   int s_fs;             // sampling frequency
@@ -142,4 +154,3 @@ FP_TYPE* llsm_synthesize(llsm_parameters param, llsm* model, int* ny);
 void llsm_delete(llsm* model);
 
 #endif
-

--- a/llsm.h
+++ b/llsm.h
@@ -54,6 +54,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
   #define FP_TYPE double
 #endif
 
+#define LLSM_HAMETHOD_QFFT 0
+#define LLSM_HAMETHOD_QHM 1
+
 /*
   llsm_sinparam: model parameters for sinusoidal signals
 */
@@ -112,11 +115,6 @@ typedef struct {
     analysis/synthesis processes. We name so to make it consistent with libpyin (see pyin_paramters).
 */
 
-typedef enum {
-  qfft = 0, // use fft spectrum peak picking on quasi-harmonic analysis
-  qhm // use Least-Square
-} llsm_harmonic_analysis_method;
-
 typedef struct {
   // params for analysis
   int a_nhop;           // hop size in samples
@@ -130,11 +128,11 @@ typedef struct {
   FP_TYPE* a_nosbandf;  // upper frequency of each noise band
   int a_nnosband;       // number of noise bands
 
-  llsm_harmonic_analysis_method a_method; // method of quasi-harmonic analysis, qfft by default
-  char a_qhmlsmethod; // method of LS. 'Q' remains QR/LR(faster). 'S' remains SVD(better quality, very slow).
+  int a_hamethod; // method of quasi-harmonic analysis, LLSM_HAMETHOD_QFFT by default
+  int a_qhmlsmethod; // method of LS, QHM_LSMETHOD_QR by default
   int a_maxairiter;  // maximum number of air iteration, 16 by default
   int a_maxqhmiter; // maximum number of qhm iteration, 4 by default
-  FP_TYPE a_maxqhmcorr; // maximum frequency correction per iteration(in Hz)
+  FP_TYPE a_maxqhmcorr; // maximum frequency correction per iteration(in Hz), 20.0 by default
 
   // params for synthesis
   int s_fs;             // sampling frequency

--- a/makefile
+++ b/makefile
@@ -1,10 +1,12 @@
-CC = gcc
-LINK = gcc -fopenmp
+export FP_TYPE ?= double
+CC ?= cc
+LINK ?= cc
+LDFLAGS += -fopenmp -llapack -lcblas -lm
 AR = ar
-CFLAGS = -Ofast -std=c99 -Wall -fPIC -fopenmp
+CFLAGS = -Ofast -std=c99 -Wall -fPIC -fopenmp -DFP_TYPE=$(FP_TYPE)
 ARFLAGS = -rv
 OUT_DIR = ./build
-OBJS = $(OUT_DIR)/fftsg_h.o $(OUT_DIR)/math-funcs.o $(OUT_DIR)/llsm.o $(OUT_DIR)/envelope.o
+OBJS = $(OUT_DIR)/fftsg_h.o $(OUT_DIR)/math-funcs.o $(OUT_DIR)/llsm.o $(OUT_DIR)/envelope.o $(OUT_DIR)/qhm.o
 LIBS =
 LIBPYIN = external/libpyin
 LIBGVPS = $(LIBPYIN)/external/libgvps
@@ -16,7 +18,7 @@ testapprox: $(OUT_DIR)/check-approx
 	$(OUT_DIR)/check-approx
 
 $(OUT_DIR)/llsm-test: $(OUT_DIR)/libllsm.a test/test.c external/matlabfunctions.c $(LIBGVPS)/build/libgvps.a $(LIBPYIN)/build/libpyin.a
-	$(LINK) $(CFLAGS) -o $(OUT_DIR)/llsm-test test/test.c external/matlabfunctions.c $(OUT_DIR)/libllsm.a $(LIBPYIN)/build/libpyin.a $(LIBGVPS)/build/libgvps.a -lm
+	$(LINK) $(CFLAGS) -o $(OUT_DIR)/llsm-test test/test.c external/matlabfunctions.c $(OUT_DIR)/libllsm.a $(LIBPYIN)/build/libpyin.a $(LIBGVPS)/build/libgvps.a $(LDFLAGS)
 
 $(OUT_DIR)/check-approx: $(OUT_DIR)/libllsm.a test/check-approx.c external/matlabfunctions.c
 	$(CC) $(CFLAGS) -o $(OUT_DIR)/check-approx test/check-approx.c external/matlabfunctions.c $(OUT_DIR)/libllsm.a -lm
@@ -34,6 +36,7 @@ $(OUT_DIR)/libllsm.a: $(OBJS)
 $(OUT_DIR)/math-funcs.o : math-funcs.c math-funcs.h common.h
 $(OUT_DIR)/llsm.o : llsm.c llsm.h envelope.h math-funcs.h common.h
 $(OUT_DIR)/envelope.o : envelope.c envelope.h math-funcs.h common.h
+$(OUT_DIR)/qhm.o: qhm.h qhm.c math-funcs.h common.h llsm.h
 
 $(OUT_DIR)/fftsg_h.o : external/fftsg_h.c
 	mkdir -p build
@@ -57,4 +60,3 @@ clear:
 	@echo 'Removing all temporary binaries... '
 	@rm -f $(OUT_DIR)/libllsm.a $(OUT_DIR)/*.o
 	@echo Done.
-

--- a/makefile
+++ b/makefile
@@ -1,17 +1,24 @@
 export FP_TYPE ?= double
 CC ?= cc
 LINK ?= cc
-LDFLAGS += -fopenmp -llapacke -llapack -lcblas -lm
+LDFLAGS += -fopenmp -lm
 AR = ar
-CFLAGS = -Ofast -std=c99 -Wall -fPIC -fopenmp -DFP_TYPE=$(FP_TYPE)
+CFLAGS += -Ofast -std=c99 -Wall -fPIC -fopenmp -DFP_TYPE=$(FP_TYPE)
 ARFLAGS = -rv
 OUT_DIR = ./build
 OBJS = $(OUT_DIR)/fftsg_h.o $(OUT_DIR)/math-funcs.o $(OUT_DIR)/llsm.o $(OUT_DIR)/envelope.o $(OUT_DIR)/qhm.o
 LIBS =
 LIBPYIN = external/libpyin
 LIBGVPS = $(LIBPYIN)/external/libgvps
+ENABLE_QHM ?= 1
+
+ifeq ($(ENABLE_QHM),1)
+	CFLAGS += -DENABLE_QHM -Wno-incompatible-pointer-types
+	LDFLAGS += -llapacke -llapack -lcblas
+endif
 
 default: $(OUT_DIR)/libllsm.a
+
 test: $(OUT_DIR)/llsm-test
 	$(OUT_DIR)/llsm-test test/arctic_a0001.wav
 testapprox: $(OUT_DIR)/check-approx

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 export FP_TYPE ?= double
 CC ?= cc
 LINK ?= cc
-LDFLAGS += -fopenmp -llapack -lcblas -lm
+LDFLAGS += -fopenmp -llapacke -llapack -lcblas -lm
 AR = ar
 CFLAGS = -Ofast -std=c99 -Wall -fPIC -fopenmp -DFP_TYPE=$(FP_TYPE)
 ARFLAGS = -rv

--- a/math-funcs.h
+++ b/math-funcs.h
@@ -32,8 +32,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 /*
   matlab-style frequency maps [0, 1] onto [0 fs/2] Hz
   llsm-style frequency maps [0, 1] onto [0 fs] Hz even though (0.5, 1] is above nyquist frequency
-  
-  All inline functions are in matlab-style; all functions beginning with llsm prefix are llsm-style.
+
+  All static inline functions are in matlab-style; all functions beginning with llsm prefix are llsm-style.
 */
 
 #ifndef LLSM_MFUNCS
@@ -69,7 +69,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 #define atan2_1 fastatan2
 
 #define def_singlepass(name, op, init) \
-inline FP_TYPE name(FP_TYPE* src, int n) { \
+static inline FP_TYPE name(FP_TYPE* src, int n) { \
   FP_TYPE ret = init; \
   for(int i = 0; i < n; i ++) \
     ret = op(ret, src[i]); \
@@ -84,35 +84,35 @@ def_singlepass(sumfp, def_add, 0)
 def_singlepass(maxfp, def_max, src[0])
 def_singlepass(minfp, def_min, src[0])
 
-inline FP_TYPE* boxcar(int n) {
+static inline FP_TYPE* boxcar(int n) {
   FP_TYPE* ret = calloc(n, sizeof(FP_TYPE));
   for(int i = 0; i < n; i ++)
     ret[i] = 1.0;
   return ret;
 }
 
-inline FP_TYPE* hanning(int n) {
+static inline FP_TYPE* hanning(int n) {
   FP_TYPE* ret = calloc(n, sizeof(FP_TYPE));
   for(int i = 0; i < n; i ++)
     ret[i] = 0.5 * (1 - cos_3(2 * M_PI * i / (n - 1)));
   return ret;
 }
 
-inline FP_TYPE* hamming(int n) {
+static inline FP_TYPE* hamming(int n) {
   FP_TYPE* ret = calloc(n, sizeof(FP_TYPE));
   for(int i = 0; i < n; i ++)
     ret[i] = 0.54 - 0.46 * cos_3(2 * M_PI * i / (n - 1));
   return ret;
 }
 
-inline FP_TYPE* mltsine(int n) {
+static inline FP_TYPE* mltsine(int n) {
   FP_TYPE* ret = calloc(n, sizeof(FP_TYPE));
   for(int i = 0; i < n; i ++)
     ret[i] = sin_3(M_PI / n * (i + 0.5));
   return ret;
 }
 
-inline FP_TYPE* blackman_harris(int n) {
+static inline FP_TYPE* blackman_harris(int n) {
   FP_TYPE* ret = calloc(n, sizeof(FP_TYPE));
   const FP_TYPE a0 = 0.35875;
   const FP_TYPE a1 = 0.48829;
@@ -125,7 +125,7 @@ inline FP_TYPE* blackman_harris(int n) {
   return ret;
 }
 
-inline FP_TYPE* blackman(int n) {
+static inline FP_TYPE* blackman(int n) {
   FP_TYPE* ret = calloc(n, sizeof(FP_TYPE));
   const FP_TYPE a0 = 0.42;
   const FP_TYPE a1 = 0.5;
@@ -146,7 +146,7 @@ FP_TYPE* llsm_filter(FP_TYPE* b, int nb, FP_TYPE* a, int na, FP_TYPE* x, int nx)
 FP_TYPE* llsm_chebyfilt(FP_TYPE* x, int nx, FP_TYPE cutoff1, FP_TYPE cutoff2, char* type);
 FP_TYPE* llsm_interp(FP_TYPE* xi, FP_TYPE* yi, int ni, FP_TYPE* x, int nx);
 
-inline double fastatan2(double y, double x) {
+static inline double fastatan2(double y, double x) {
   double coeff_1 = M_PI / 4.0;
   double coeff_2 = 3.0 * coeff_1;
   double abs_y = fabs(y) + 1e-10; // kludge to prevent 0/0 condition
@@ -164,7 +164,7 @@ inline double fastatan2(double y, double x) {
    return angle;
 }
 
-inline void fft_core(FP_TYPE* xr, FP_TYPE* xi, FP_TYPE* yr, FP_TYPE* yi, int n, FP_TYPE* buffer, FP_TYPE mode) {
+static inline void fft_core(FP_TYPE* xr, FP_TYPE* xi, FP_TYPE* yr, FP_TYPE* yi, int n, FP_TYPE* buffer, FP_TYPE mode) {
   for(int i = 0; i < n; i ++) {
     buffer[i * 2] = xr == NULL ? 0 : xr[i];
     buffer[i * 2 + 1] = xi == NULL ? 0 : xi[i];
@@ -182,19 +182,19 @@ inline void fft_core(FP_TYPE* xr, FP_TYPE* xi, FP_TYPE* yr, FP_TYPE* yi, int n, 
     }
 }
 
-inline void fft(FP_TYPE* xr, FP_TYPE* xi, FP_TYPE* yr, FP_TYPE* yi, int n, FP_TYPE* buffer) {
+static inline void fft(FP_TYPE* xr, FP_TYPE* xi, FP_TYPE* yr, FP_TYPE* yi, int n, FP_TYPE* buffer) {
   fft_core(xr, xi, yr, yi, n, buffer, -1.0);
 }
 
-inline void ifft(FP_TYPE* xr, FP_TYPE* xi, FP_TYPE* yr, FP_TYPE* yi, int n, FP_TYPE* buffer) {
+static inline void ifft(FP_TYPE* xr, FP_TYPE* xi, FP_TYPE* yr, FP_TYPE* yi, int n, FP_TYPE* buffer) {
   fft_core(xr, xi, yr, yi, n, buffer, 1.0);
 }
 
-inline void idft(FP_TYPE* xr, FP_TYPE* xi, FP_TYPE* yr, FP_TYPE* yi, int n) {
+static inline void idft(FP_TYPE* xr, FP_TYPE* xi, FP_TYPE* yr, FP_TYPE* yi, int n) {
   llsm_idft(xr, xi, yr, yi, n);
 }
 
-inline FP_TYPE* fftshift(FP_TYPE* x, int n) {
+static inline FP_TYPE* fftshift(FP_TYPE* x, int n) {
   FP_TYPE* y = calloc(n, sizeof(FP_TYPE));
   int halfs = n / 2;
   int halfl = (n + 1) / 2;
@@ -205,7 +205,7 @@ inline FP_TYPE* fftshift(FP_TYPE* x, int n) {
   return y;
 }
 
-inline FP_TYPE* unwrap(FP_TYPE* x, int n) {
+static inline FP_TYPE* unwrap(FP_TYPE* x, int n) {
   FP_TYPE* y = calloc(n, sizeof(FP_TYPE));
   y[0] = x[0];
   for(int i = 1; i < n; i ++) {
@@ -217,74 +217,74 @@ inline FP_TYPE* unwrap(FP_TYPE* x, int n) {
   return y;
 }
 
-inline FP_TYPE* abscplx(FP_TYPE* xr, FP_TYPE* xi, int n) {
+static inline FP_TYPE* abscplx(FP_TYPE* xr, FP_TYPE* xi, int n) {
   FP_TYPE* y = calloc(n, sizeof(FP_TYPE));
   for(int i = 0; i < n; i ++)
     y[i] = sqrt(xr[i] * xr[i] + xi[i] * xi[i]);
   return y;
 }
 
-inline FP_TYPE* argcplx(FP_TYPE* xr, FP_TYPE* xi, int n) {
+static inline FP_TYPE* argcplx(FP_TYPE* xr, FP_TYPE* xi, int n) {
   FP_TYPE* y = calloc(n, sizeof(FP_TYPE));
   for(int i = 0; i < n; i ++)
     y[i] = atan2_3(xi[i], xr[i]);
   return y;
 }
 
-inline FP_TYPE linterp(FP_TYPE v1, FP_TYPE v2, FP_TYPE ratio) {
+static inline FP_TYPE linterp(FP_TYPE v1, FP_TYPE v2, FP_TYPE ratio) {
     return v1 + (v2 - v1) * ratio;
 }
 
-inline void complete_symm(FP_TYPE* x, int n) {
+static inline void complete_symm(FP_TYPE* x, int n) {
   if(n / 2 == (n + 1) / 2) // even
     x[n / 2] = x[n / 2 - 1];
   for(int i = n / 2 + 1; i < n; i ++)
     x[i] = x[n - i];
 }
 
-inline void complete_asymm(FP_TYPE* x, int n) {
+static inline void complete_asymm(FP_TYPE* x, int n) {
   if(n / 2 == (n + 1) / 2) // even
     x[n / 2] = x[n / 2 - 1];
   for(int i = n / 2 + 1; i < n; i ++)
     x[i] = -x[n - i];
 }
 
-inline FP_TYPE* fir1(int order, FP_TYPE cutoff, char* type, char* window) {
+static inline FP_TYPE* fir1(int order, FP_TYPE cutoff, char* type, char* window) {
   return llsm_winfir(order, cutoff / 2.0, 0, type, window);
 }
 
-inline FP_TYPE* fir1bp(int order, FP_TYPE cutoff_low, FP_TYPE cutoff_high, char* window) {
+static inline FP_TYPE* fir1bp(int order, FP_TYPE cutoff_low, FP_TYPE cutoff_high, char* window) {
   return llsm_winfir(order, cutoff_low / 2.0, cutoff_high / 2.0, "bandpass", window);
 }
 
-inline int cheby1_fixed(FP_TYPE cutoff, char* type, FP_TYPE** a, FP_TYPE** b) {
+static inline int cheby1_fixed(FP_TYPE cutoff, char* type, FP_TYPE** a, FP_TYPE** b) {
   return llsm_get_iir_filter(cutoff / 2.0, type, a, b);
 }
 
-inline FP_TYPE* conv(FP_TYPE* x, FP_TYPE* h, int nx, int nh) {
+static inline FP_TYPE* conv(FP_TYPE* x, FP_TYPE* h, int nx, int nh) {
   return llsm_convolution(x, h, nx, nh);
 }
 
-inline FP_TYPE* filter(FP_TYPE* b, int nb, FP_TYPE* a, int na, FP_TYPE* x, int nx) {
+static inline FP_TYPE* filter(FP_TYPE* b, int nb, FP_TYPE* a, int na, FP_TYPE* x, int nx) {
   return llsm_filter(b, nb, a, na, x, nx);
 }
 
-inline FP_TYPE* chebyfilt(FP_TYPE* x, int nx, FP_TYPE cutoff1, FP_TYPE cutoff2, char* type) {
+static inline FP_TYPE* chebyfilt(FP_TYPE* x, int nx, FP_TYPE cutoff1, FP_TYPE cutoff2, char* type) {
   return llsm_chebyfilt(x, nx, cutoff1 / 2.0, cutoff2 / 2.0, type);
 }
 
-inline FP_TYPE* interp1(FP_TYPE* xi, FP_TYPE* yi, int ni, FP_TYPE* x, int nx) {
+static inline FP_TYPE* interp1(FP_TYPE* xi, FP_TYPE* yi, int ni, FP_TYPE* x, int nx) {
   return llsm_interp(xi, yi, ni, x, nx);
 }
 
-inline FP_TYPE* white_noise(FP_TYPE amplitude, int n) {
+static inline FP_TYPE* white_noise(FP_TYPE amplitude, int n) {
   FP_TYPE* y = calloc(n, sizeof(FP_TYPE));
   for(int i = 0; i < n; i ++)
     y[i] = ((FP_TYPE)rand() / RAND_MAX - 0.5) * amplitude * 2.0;
   return y;
 }
 
-inline FP_TYPE* moving_avg(FP_TYPE* x, int nx, int order) {
+static inline FP_TYPE* moving_avg(FP_TYPE* x, int nx, int order) {
   FP_TYPE* h = boxcar(order);
   for(int i = 0; i < order; i ++) h[i] /= order;
   FP_TYPE* y = conv(x, h, nx, order);
@@ -293,4 +293,3 @@ inline FP_TYPE* moving_avg(FP_TYPE* x, int nx, int order) {
 }
 
 #endif
-

--- a/math-funcs.h
+++ b/math-funcs.h
@@ -145,6 +145,9 @@ FP_TYPE* llsm_convolution(FP_TYPE* x, FP_TYPE* h, int nx, int nh);
 FP_TYPE* llsm_filter(FP_TYPE* b, int nb, FP_TYPE* a, int na, FP_TYPE* x, int nx);
 FP_TYPE* llsm_chebyfilt(FP_TYPE* x, int nx, FP_TYPE cutoff1, FP_TYPE cutoff2, char* type);
 FP_TYPE* llsm_interp(FP_TYPE* xi, FP_TYPE* yi, int ni, FP_TYPE* x, int nx);
+FP_TYPE llsm_stdev(FP_TYPE* x, int n);
+// length of 'work' array is n
+FP_TYPE llsm_calc_srer(FP_TYPE* x, FP_TYPE* y, int n, FP_TYPE* work);
 
 static inline double fastatan2(double y, double x) {
   double coeff_1 = M_PI / 4.0;

--- a/qhm.c
+++ b/qhm.c
@@ -37,32 +37,30 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 
 typedef FP_TYPE*(*window_getter)(int);
 
-static int isshowprogress = 1;
+static int show_progress = 1;
 
 void qhm_progress(int v) {
-  isshowprogress = v;
+  show_progress = v;
 }
 
-void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int nhop, const char* wtype) {
+void qhm_air(llsm_parameters param, FP_TYPE* x,
+  int nx, int fs, FP_TYPE* f0, int nhop, const char* wtype) {
+
   double window_periods = 2.5;
   window_getter window_func;
   if(! strcmp(wtype, "blackman_harris")) {
     window_func = blackman_harris;
     window_periods = 2.2;
-  }
-  else if(! strcmp(wtype, "hamming")) {
+  } else if(! strcmp(wtype, "hamming")) {
     window_func = hamming;
     window_periods = 1.5;
-  }
-  else if(! strcmp(wtype, "hanning")) {
+  } else if(! strcmp(wtype, "hanning")) {
     window_func = hanning;
     window_periods = 1.5;
-  }
-  else if(! strcmp(wtype, "blackman")) {
+  } else if(! strcmp(wtype, "blackman")) {
     window_func = blackman;
     window_periods = 1.65;
-  }
-  else {
+  } else {
     fprintf(stderr, "Unknown window type %s. Aborting...", wtype);
     abort();
   }
@@ -76,12 +74,12 @@ void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int
   int lastoutputed = 0;
   double sumsrer = 0.0;
   int nvoiced = 0;
-  for(int ihop = 0; ihop < nhop; ++ ihop) {
+  for(int ihop = 0; ihop < nhop; ihop ++) {
     if(f0[ihop] <= 0.0) continue;
     ++nvoiced;
 
-    if(isshowprogress) {
-      for(int i = 0; i < lastoutputed; ++ i)
+    if(show_progress) {
+      for(int i = 0; i < lastoutputed; i ++)
         printf("\b");
       lastoutputed = printf("AIR: %d / %d", ihop, nhop);
       fflush(stdout);
@@ -89,27 +87,29 @@ void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int
 
     // get comparison frame
     FP_TYPE* c_frame = fetch_frame(x, nx, ihop * param.a_nhop, param.a_nhop * 2);
-    for(int i = 0; i < param.a_nhop * 2; ++ i) {
+    for(int i = 0; i < param.a_nhop * 2; i ++) {
       s_range[i] = i - param.a_nhop;
       c_frame[i] *= s_window[i];
     }
 
     // do iterations
     FP_TYPE lastsrer = -INFINITY;
-    for(int iiter = 0; iiter < param.a_maxairiter; ++ iiter) {
+    for(int iiter = 0; iiter < param.a_maxairiter; iiter ++) {
       // analysis
       int nhar = param.a_mvf / f0[ihop];
       int winlen = (int)(((FP_TYPE)fs) / f0[ihop] * window_periods) * 2 + 1;
       FP_TYPE* a_window = window_func(winlen);
       FP_TYPE* a_frame = fetch_frame(x, nx, ihop * param.a_nhop, winlen);
-      qhm_solve_status *status = qhm_status_init(a_frame, a_window, f0[ihop], param.a_maxqhmcorr, winlen, fs, nhar, param.a_qhmlsmethod);
+      qhm_solve_status *status = qhm_status_init(a_frame, a_window, f0[ihop], param.a_maxqhmcorr,
+        winlen, fs, nhar, param.a_qhmlsmethod);
       int info = qhm_iter(status);
       if(info != 0) abort(); // error occurred
 
       // synthesis and calculate srer
-      double complex* s_work = calloc(sizeof(double complex), (status->K + 1) * param.a_nhop * 2);
-      qhm_synth(status->lstsqb, status->fk_hat, s_range, s_frame, status->K, param.a_nhop * 2, fs, s_work);
-      for(int i = 0; i < param.a_nhop * 2; ++ i)
+      double complex* s_work = calloc(sizeof(double complex), (status -> K + 1) * param.a_nhop * 2);
+      qhm_synth(status -> lstsqb, status -> fk_hat, s_range, s_frame,
+        status -> K, param.a_nhop * 2, fs, s_work);
+      for(int i = 0; i < param.a_nhop * 2; i ++)
         s_frame[i] *= s_window[i];
       FP_TYPE currsrer = qhm_calc_srer(c_frame, s_frame, param.a_nhop * 2, srer_work);
 
@@ -117,8 +117,8 @@ void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int
       if(currsrer > lastsrer) {
         int nmean = nhar / 3 > 16 ? 16 : nhar / 3;
         FP_TYPE meanf0 = 0.0;
-        for(int i = 0; i < nmean; ++ i)
-          meanf0 += status->fk_hat[nhar + 1 + i] / (i + 1);
+        for(int i = 0; i < nmean; i ++)
+          meanf0 += status -> fk_hat[nhar + 1 + i] / (i + 1);
         meanf0 /= nmean;
         f0[ihop] = meanf0;
       }
@@ -128,7 +128,7 @@ void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int
         if(currsrer > lastsrer)
           lastsrer = currsrer;
         free(s_work);
-        qhm_status_free(status);
+        delete_status_free(status);
         free(a_frame);
         free(a_window);
         break;
@@ -138,7 +138,7 @@ void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int
         lastsrer = currsrer;
 
       free(s_work);
-      qhm_status_free(status);
+      delete_status_free(status);
       free(a_frame);
       free(a_window);
     }
@@ -146,8 +146,8 @@ void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int
     free(c_frame);
   }
 
-  if(isshowprogress) {
-    for(int i = 0; i < lastoutputed; ++ i)
+  if(show_progress) {
+    for(int i = 0; i < lastoutputed; i ++)
       printf("\b");
     printf("AIR finished. Average SRER = %lf.\n", sumsrer / nvoiced);
   }
@@ -158,26 +158,24 @@ void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int
   free(s_window);
 }
 
-void qhm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int nhop, llsm_sinparam* sinu, const char* wtype) {
+void qhm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs,
+  FP_TYPE* f0, int nhop, llsm_sinparam* sinu, const char* wtype) {
+
   double window_periods = 2.5;
   window_getter window_func;
   if(! strcmp(wtype, "blackman_harris")) {
     window_func = blackman_harris;
     window_periods = 2.2;
-  }
-  else if(! strcmp(wtype, "hamming")) {
+  } else if(! strcmp(wtype, "hamming")) {
     window_func = hamming;
     window_periods = 1.5;
-  }
-  else if(! strcmp(wtype, "hanning")) {
+  } else if(! strcmp(wtype, "hanning")) {
     window_func = hanning;
     window_periods = 1.5;
-  }
-  else if(! strcmp(wtype, "blackman")) {
+  } else if(! strcmp(wtype, "blackman")) {
     window_func = blackman;
     window_periods = 1.65;
-  }
-  else {
+  } else {
     fprintf(stderr, "Unknown window type %s. Aborting...", wtype);
     abort();
   }
@@ -191,12 +189,12 @@ void qhm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0,
   double sumsrer = 0.0;
   int nvoiced = 0;
 
-  for(int ihop = 0; ihop < nhop; ++ ihop) {
+  for(int ihop = 0; ihop < nhop; ihop ++) {
     if(f0[ihop] <= 0.0) continue;
     ++nvoiced;
 
-    if(isshowprogress) {
-      for(int i = 0; i < lastoutputed; ++ i)
+    if(show_progress) {
+      for(int i = 0; i < lastoutputed; i ++)
         printf("\b");
       lastoutputed = printf("QHM: %d / %d", ihop, nhop);
       fflush(stdout);
@@ -204,7 +202,7 @@ void qhm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0,
 
     // get comparison frame and analysis frame
     FP_TYPE* c_frame = fetch_frame(x, nx, ihop * param.a_nhop, param.a_nhop * 2);
-    for(int i = 0; i < param.a_nhop * 2; ++ i) {
+    for(int i = 0; i < param.a_nhop * 2; i ++) {
       s_range[i] = i - param.a_nhop;
       c_frame[i] *= s_window[i];
     }
@@ -213,27 +211,29 @@ void qhm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0,
     int winlen = (int)(((FP_TYPE)fs) / f0[ihop] * window_periods) * 2 + 1;
     FP_TYPE* a_window = window_func(winlen);
     FP_TYPE* a_frame = fetch_frame(x, nx, ihop * param.a_nhop, winlen);
-    qhm_solve_status *status = qhm_status_init(a_frame, a_window, f0[ihop], param.a_maxqhmcorr, winlen, fs, nhar, param.a_qhmlsmethod);
+    qhm_solve_status* status = qhm_status_init(a_frame, a_window, f0[ihop], param.a_maxqhmcorr,
+      winlen, fs, nhar, param.a_qhmlsmethod);
     FP_TYPE bestsrer = -INFINITY;
-    double complex* bestak = calloc(sizeof(double complex), status->K);
-    FP_TYPE* bestfk_hat = calloc(sizeof(FP_TYPE), status->K);
+    double complex* bestak = calloc(sizeof(double complex), status -> K);
+    FP_TYPE* bestfk_hat = calloc(sizeof(FP_TYPE), status -> K);
 
     // iteration
-    for(int iiter = 0; iiter < param.a_maxqhmiter; ++ iiter) {
+    for(int iiter = 0; iiter < param.a_maxqhmiter; iiter ++) {
       // analysis
       int info = qhm_iter(status);
       if(info != 0) abort(); // error occurred
 
       // synthesis and calculate srer
-      qhm_synth_half(status->lstsqb, status->fk_hat, s_range, s_frame, status->K, param.a_nhop * 2, fs);
-      for(int i = 0; i < param.a_nhop * 2; ++ i)
+      qhm_synth_half(status -> lstsqb, status -> fk_hat, s_range, s_frame,
+        status -> K, param.a_nhop * 2, fs);
+      for(int i = 0; i < param.a_nhop * 2; i ++)
         s_frame[i] *= s_window[i];
       FP_TYPE currsrer = qhm_calc_srer(c_frame, s_frame, param.a_nhop * 2, srer_work);
       // check whether update bestak
       if(currsrer > bestsrer) {
         bestsrer = currsrer;
-        memcpy(bestfk_hat, status->fk_hat, status->K * sizeof(FP_TYPE));
-        memcpy(bestak, status->lstsqb, status->K * sizeof(double complex));
+        memcpy(bestfk_hat, status -> fk_hat, status -> K * sizeof(FP_TYPE));
+        memcpy(bestak, status -> lstsqb, status -> K * sizeof(double complex));
       }
     }
 
@@ -242,19 +242,20 @@ void qhm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0,
       fprintf(stderr, "QHM: Failed to analyze at %d. Aborting...\n", ihop);
       abort();
     }
-    qhm_harmonic_parameter_from_ak(bestak, bestfk_hat, status->K, param.a_nhar, sinu -> freq[ihop], sinu -> ampl[ihop], sinu -> phse[ihop]);
+    qhm_harmonic_parameter_from_ak(bestak, bestfk_hat, status -> K, param.a_nhar,
+      sinu -> freq[ihop], sinu -> ampl[ihop], sinu -> phse[ihop]);
     sumsrer += bestsrer;
 
     free(bestfk_hat);
     free(bestak);
-    qhm_status_free(status);
+    delete_status_free(status);
     free(a_frame);
     free(a_window);
     free(c_frame);
   }
 
-  if(isshowprogress) {
-    for(int i = 0; i < lastoutputed; ++ i)
+  if(show_progress) {
+    for(int i = 0; i < lastoutputed; i ++)
       printf("\b");
     printf("QHM finished. Average SRER = %lf.\n", sumsrer / nvoiced);
   }
@@ -265,28 +266,30 @@ void qhm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0,
   free(s_window);
 }
 
-qhm_solve_status* qhm_status_init(FP_TYPE* x, FP_TYPE* window, FP_TYPE f0, FP_TYPE maxcorr, int nx, int fs, int nhar, char lsmethod) {
+qhm_solve_status* qhm_status_init(FP_TYPE* x, FP_TYPE* window, FP_TYPE f0, FP_TYPE maxcorr,
+  int nx, int fs, int nhar, int lsmethod) {
+
   qhm_solve_status *status = calloc(sizeof(qhm_solve_status), 1);
 
-  status->x = x;
-  status->window = window;
-  status->f0 = f0;
-  status->maxcorr = maxcorr;
-  status->nx = nx;
-  status->fs = fs;
-  status->nhar = nhar;
-  status->ls_method = lsmethod;
+  status -> x = x;
+  status -> window = window;
+  status -> f0 = f0;
+  status -> maxcorr = maxcorr;
+  status -> nx = nx;
+  status -> fs = fs;
+  status -> nhar = nhar;
+  status -> ls_method = lsmethod;
 
-  status->K = status->nhar * 2 + 1;
-  status->N = (status->nx - 1) / 2;
-  status->fk_hat = calloc(sizeof(FP_TYPE), status->K);
-  status->n = calloc(sizeof(FP_TYPE), nx);
-  status->t = calloc(sizeof(FP_TYPE), status->K * nx);
-  status->Ea = calloc(sizeof(double complex), 2 * status->K * nx);
-  status->Ew = calloc(sizeof(double complex), nx * 2 * status->K);
-  status->R = calloc(sizeof(double complex), 2 * status->K * 2 * status->K);
-  status->windowed_x = calloc(sizeof(double complex), nx);
-  status->lstsqb = calloc(sizeof(double complex), 2 * status->K);
+  status -> K = status -> nhar * 2 + 1;
+  status -> N = (status -> nx - 1) / 2;
+  status -> fk_hat = calloc(sizeof(FP_TYPE), status -> K);
+  status -> n = calloc(sizeof(FP_TYPE), nx);
+  status -> t = calloc(sizeof(FP_TYPE), status -> K * nx);
+  status -> Ea = calloc(sizeof(double complex), 2 * status -> K * nx);
+  status -> Ew = calloc(sizeof(double complex), nx * 2 * status -> K);
+  status -> R = calloc(sizeof(double complex), 2 * status -> K * 2 * status -> K);
+  status -> windowed_x = calloc(sizeof(double complex), nx);
+  status -> lstsqb = calloc(sizeof(double complex), 2 * status -> K);
 
   qhm_status_reset(status);
 
@@ -294,21 +297,21 @@ qhm_solve_status* qhm_status_init(FP_TYPE* x, FP_TYPE* window, FP_TYPE f0, FP_TY
 }
 
 void qhm_status_reset(qhm_solve_status* status) {
-  for(int i = -status->nhar; i < status->nhar + 1; ++ i)
-    status->fk_hat[i + status->nhar] = ((FP_TYPE)i) * status->f0;
-  for(int i = -status->N; i < status->N + 1; ++ i)
-    status->n[i + status->N] = (FP_TYPE)i;
+  for(int i = -status -> nhar; i < status -> nhar + 1; i ++)
+    status -> fk_hat[i + status -> nhar] = ((FP_TYPE)i) * status -> f0;
+  for(int i = -status -> N; i < status -> N + 1; i ++)
+    status -> n[i + status -> N] = (FP_TYPE)i;
 }
 
-void qhm_status_free(qhm_solve_status* status) {
-  free(status->fk_hat);
-  free(status->n);
-  free(status->t);
-  free(status->Ea);
-  free(status->Ew);
-  free(status->R);
-  free(status->windowed_x);
-  free(status->lstsqb);
+void delete_status_free(qhm_solve_status* status) {
+  free(status -> fk_hat);
+  free(status -> n);
+  free(status -> t);
+  free(status -> Ea);
+  free(status -> Ew);
+  free(status -> R);
+  free(status -> windowed_x);
+  free(status -> lstsqb);
 
   free(status);
 }
@@ -317,59 +320,61 @@ int qhm_iter(qhm_solve_status* status) {
   int m, n, k;
   /* LS Analysis */
   // t = np.dot(2 * np.pi * fk_hat, n) / sr
-  for(int row = 0; row < status->K; ++ row) {
-    double a = 2.0 * M_PI * status->fk_hat[row] / (FP_TYPE)status->fs;
-    for(int col = 0; col < status->nx; ++col)
-      status->t[row * status->nx + col] = a * status->n[col];
+  for(int row = 0; row < status -> K; ++ row) {
+    double a = 2.0 * M_PI * status -> fk_hat[row] / (FP_TYPE)status -> fs;
+    for(int col = 0; col < status -> nx; ++col)
+      status -> t[row * status -> nx + col] = a * status -> n[col];
   }
 
   // E = np.cos(t) + 1j * np.sin(t), mat with cplx exp
   // Ea = np.concatenate((E, np.tile(n, (K, 1)) * E), axis = 0)
-  int base = status->K * status->nx;
-  for(int i = 0; i < base; ++ i)
-    status->Ea[i] = cos(status->t[i]) + sin(status->t[i]) * I;
-  for(int i = 0; i < base; ++ i)
-    status->Ea[i + base] = status->Ea[i] * status->n[i % status->nx];
+  int base = status -> K * status -> nx;
+  for(int i = 0; i < base; i ++)
+    status -> Ea[i] = cos(status -> t[i]) + sin(status -> t[i]) * I;
+  for(int i = 0; i < base; i ++)
+    status -> Ea[i + base] = status -> Ea[i] * status -> n[i % status -> nx];
   // Ew = np.tile(window, (1, 2 * K)) * Ea.T # multiply the window
-  for(int row = 0; row < status->nx; ++ row)
-    for(int col = 0; col < 2 * status->K; ++col)
-      status->Ew[row * 2 * status->K + col] = status->window[row] * status->Ea[col * status->nx + row];
+  for(int row = 0; row < status -> nx; ++ row)
+    for(int col = 0; col < 2 * status -> K; ++col)
+      status -> Ew[row * 2 * status -> K + col] = status -> window[row] *
+        status -> Ea[col * status -> nx + row];
 
   // R = np.dot(Ew.T, Ew), compute the matrix to be inverted
-  m = 2 * status->K;
-  n = 2 * status->K;
-  k = status->nx;
+  m = 2 * status -> K;
+  n = 2 * status -> K;
+  k = status -> nx;
   double complex alpha = 1.0, beta = 0.0;
   cblas_zgemm(CblasRowMajor, CblasTrans, CblasNoTrans,
-    m, n, k, &alpha,
-    status->Ew, m,
-    status->Ew, n,
-    &beta, status->R, n
+    m, n, k, & alpha,
+    status -> Ew, m,
+    status -> Ew, n,
+    & beta, status -> R, n
   );
   // lstsqb = np.dot(Ew.T, x * window)
-  for(int i = 0; i < status->nx; ++ i)
-    status->windowed_x[i] = status->x[i] * status->window[i];
-  m = 2 * status->K;
+  for(int i = 0; i < status -> nx; i ++)
+    status -> windowed_x[i] = status -> x[i] * status -> window[i];
+  m = 2 * status -> K;
   n = 1;
-  k = status->nx;
+  k = status -> nx;
   cblas_zgemm(CblasRowMajor, CblasTrans, CblasNoTrans,
-    m, n, k, &alpha,
-    status->Ew, m,
-    status->windowed_x, n,
-    &beta, status->lstsqb, n
+    m, n, k, & alpha,
+    status -> Ew, m,
+    status -> windowed_x, n,
+    & beta, status -> lstsqb, n
   );
 
   // theta = sla.lstsq(R, lstsqb)[0]
   int rank;
-  m = 2 * status->K;
-  n = 2 * status->K;
+  m = 2 * status -> K;
+  n = 2 * status -> K;
   int nrhs = 1;
-  double s[2 * status->K];
+  double s[2 * status -> K];
   int info;
-  if(status->ls_method == 'Q')
-    info = LAPACKE_zgels(LAPACK_ROW_MAJOR, 'N', m, n, nrhs, status->R, n, status->lstsqb, nrhs);
-  else if(status->ls_method == 'S')
-    info = LAPACKE_zgelsd(LAPACK_ROW_MAJOR, m, n, nrhs, status->R, n, status->lstsqb, nrhs, s, -1.0, &rank);
+  if(status -> ls_method == QHM_LSMETHOD_QR)
+    info = LAPACKE_zgels(LAPACK_ROW_MAJOR, 'N', m, n, nrhs, status -> R, n, status -> lstsqb, nrhs);
+  else if(status -> ls_method == QHM_LSMETHOD_SVD)
+    info = LAPACKE_zgelsd(LAPACK_ROW_MAJOR, m, n, nrhs, status -> R, n,
+      status -> lstsqb, nrhs, s, -1.0, & rank);
   else {
     fprintf(stderr, "Invalid ls_method.\n");
     abort();
@@ -378,27 +383,31 @@ int qhm_iter(qhm_solve_status* status) {
   if(info > 0) {
     fprintf(stderr, "Least-square calculation failed.\n");
     return info;
-  }
-  else if(info < 0) {
+  } else if(info < 0) {
     fprintf(stderr, "Wrong parameter.\n");
     abort();
   }
 
   // corr
-  // fk_hat += np.clip(sr / (2 * np.pi) * (ak.real * bk.imag - ak.imag * bk.real) / (np.abs(ak) ** 2), -maxCorr, maxCorr)
-  base = status->K;
-  for(int i = 0; i < status->K; ++i) {
-    double absak = cabs(status->lstsqb[i]);
-    double delta = status->fs / (2.0 * M_PI) * (creal(status->lstsqb[i]) * cimag(status->lstsqb[base + i]) - cimag(status->lstsqb[i]) * creal(status->lstsqb[base + i])) / (absak * absak);
-    if(delta > status->maxcorr) delta = status->maxcorr;
-    else if(delta < -status->maxcorr) delta = -status->maxcorr;
-    status->fk_hat[i] += delta;
+  // fk_hat += np.clip(sr / (2 * np.pi) * (ak.real * bk.imag - ak.imag * bk.real) /
+  // (np.abs(ak) ** 2), -maxCorr, maxCorr)
+  base = status -> K;
+  for(int i = 0; i < status -> K; i ++) {
+    double absak = cabs(status -> lstsqb[i]);
+    double delta = status -> fs / (2.0 * M_PI) *
+      (creal(status -> lstsqb[i]) * cimag(status -> lstsqb[base + i]) -
+      cimag(status -> lstsqb[i]) * creal(status -> lstsqb[base + i])) / (absak * absak);
+    if(delta > status -> maxcorr) delta = status -> maxcorr;
+    else if(delta < -status -> maxcorr) delta = -status -> maxcorr;
+    status -> fk_hat[i] += delta;
   }
 
   return 0;
 }
 
-void qhm_synth(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE* out, int K, int nout, int fs, double complex* work) {
+void qhm_synth(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE* out,
+  int K, int nout, int fs, double complex* work) {
+
   int needfree = 0;
   if(work == NULL) {
     work = calloc(sizeof(double complex*), (K + 1) * nout);
@@ -422,13 +431,13 @@ void qhm_synth(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE
   k = K;
   double complex alpha = 1.0, beta = 0.0;
   cblas_zgemm(CblasRowMajor, CblasTrans, CblasNoTrans,
-    m, n, k, &alpha,
+    m, n, k, & alpha,
     ak, m,
     dotb, n,
-    &beta, outtemp, n
+    & beta, outtemp, n
   );
 
-  for(int i = 0; i < nout; ++i)
+  for(int i = 0; i < nout; i ++)
     out[i] = creal(outtemp[i]);
 
   if(needfree) free(work);
@@ -437,7 +446,7 @@ void qhm_synth(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE
 FP_TYPE qhm_stdev(FP_TYPE* x, int n) {
   FP_TYPE mean = sumfp(x, n) / n;
   FP_TYPE sum_deviation = 0.0;
-  for(int i = 0; i < n; ++ i)
+  for(int i = 0; i < n; i ++)
     sum_deviation += (x[i] - mean) * (x[i] - mean);
   return sqrt(sum_deviation / n);
 }
@@ -449,7 +458,7 @@ FP_TYPE qhm_calc_srer(FP_TYPE* x, FP_TYPE* y, int n, FP_TYPE* work) {
     needfree = 1;
   }
 
-  for(int i = 0; i < n; ++ i)
+  for(int i = 0; i < n; i ++)
     work[i] = x[i] - y[i];
 
   FP_TYPE orig_stdev = qhm_stdev(x, n);
@@ -460,33 +469,36 @@ FP_TYPE qhm_calc_srer(FP_TYPE* x, FP_TYPE* y, int n, FP_TYPE* work) {
   return log10(orig_stdev / delta_stdev) * 20.0;
 }
 
-void qhm_synth_half(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE* out, int K, int nout, int fs) {
+void qhm_synth_half(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange,
+  FP_TYPE* out, int K, int nout, int fs) {
+
   int nhar = (K - 1) / 2;
-  for(int i = 0; i < nout; ++ i)
+  for(int i = 0; i < nout; i ++)
     out[i] = 0.0;
-  for(int ihar = 0; ihar < nhar; ++ ihar) {
+  for(int ihar = 0; ihar < nhar; ihar ++) {
     double freq = fk_hat[nhar + 1 + ihar];
     double ampl = cabs(ak[nhar + 1 + ihar]) * 2.0;
     double phse = carg(ak[nhar + 1 + ihar]);
     double fph = 2.0 * M_PI / ((double)fs) * freq;
-    for(int i = 0; i < nout; ++ i)
+    for(int i = 0; i < nout; i ++)
       out[i] += cos(fph * ((double)synthrange[i]) + phse) * ampl;
   }
 }
 
-void qhm_harmonic_parameter_from_ak(double complex* ak, FP_TYPE* fk_hat, int K, int nhar, FP_TYPE* freq, FP_TYPE* ampl, FP_TYPE* phse)
-{
+void qhm_harmonic_parameter_from_ak(double complex* ak, FP_TYPE* fk_hat, int K, int nhar,
+  FP_TYPE* freq, FP_TYPE* ampl, FP_TYPE* phse) {
+
   int akhar = (K - 1) / 2;
   int outhar = akhar < nhar ? akhar : nhar;
 
-  for(int i = 0; i < outhar; ++i) {
+  for(int i = 0; i < outhar; i ++) {
     freq[i] = fk_hat[akhar + 1 + i];
     ampl[i] = cabs(ak[akhar + 1 + i]) * 2.0;
     phse[i] = carg(ak[akhar + 1 + i]);
   }
 
   FP_TYPE* phse_ = unwrap(phse, outhar);
-  for(int i = 0; i < outhar; ++i)
+  for(int i = 0; i < outhar; i ++)
     phse[i] = phse_[i];
   free(phse_);
 }

--- a/qhm.c
+++ b/qhm.c
@@ -330,6 +330,10 @@ int qhm_iter(qhm_solve_status* status) {
     info = LAPACKE_zgels(LAPACK_ROW_MAJOR, 'N', m, n, nrhs, status->R, n, status->lstsqb, nrhs);
   else if(status->ls_method == 'S')
     info = LAPACKE_zgelsd(LAPACK_ROW_MAJOR, m, n, nrhs, status->R, n, status->lstsqb, nrhs, s, -1.0, &rank);
+  else {
+    fprintf(stderr, "Invalid ls_method.\n");
+    abort();
+  }
 
   if(info > 0) {
     fprintf(stderr, "Least-square calculation failed.\n");

--- a/qhm.c
+++ b/qhm.c
@@ -1,0 +1,442 @@
+/*
+qhm.c - Quasi-Harmonic Model with Adaptive Iterative Refinement
+===
+Copyright (c) 2016 tuxzz. All rights reserved.
+Developed by: tuxzz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+    Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimers.
+    Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimers in the documentation
+and/or other materials provided with the distribution.
+    Neither the names of development group, institution, nor the names of its
+contributors may be used to endorse or promote products derived from this
+Software without specific prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE CONTRIBUTORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
+*/
+
+#include "qhm.h"
+#include <stdio.h>
+#include <math.h>
+#include <cblas.h>
+#include <lapacke.h>
+#include "math-funcs.h"
+
+typedef FP_TYPE*(*window_getter)(int);
+
+void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int nhop, const char* wtype) {
+  double window_periods = 2.5;
+  window_getter window_func;
+  if(! strcmp(wtype, "blackman_harris")) {
+    window_func = blackman_harris;
+    window_periods = 2.2;
+  }
+  else if(! strcmp(wtype, "hamming")) {
+    window_func = hamming;
+    window_periods = 1.5;
+  }
+  else if(! strcmp(wtype, "hanning")) {
+    window_func = hanning;
+    window_periods = 1.5;
+  }
+  else if(! strcmp(wtype, "blackman")) {
+    window_func = blackman;
+    window_periods = 1.65;
+  }
+  else {
+    fprintf(stderr, "Unknown window type %s. Aborting...", wtype);
+    abort();
+  }
+
+  FP_TYPE* s_window = hanning(param.a_nhop * 2);
+  FP_TYPE* s_frame = calloc(sizeof(FP_TYPE), param.a_nhop * 2);
+  FP_TYPE* s_range = calloc(sizeof(FP_TYPE), param.a_nhop * 2);
+  FP_TYPE* srer_work = calloc(sizeof(FP_TYPE), param.a_nhop * 2);
+
+  // F0 adaptive iterative refinement
+  for(int ihop = 0; ihop < nhop; ++ ihop) {
+    if(f0[ihop] <= 0.0) continue;
+    printf("AIR: %d / %d\n", ihop, nhop);
+    // get comparison frame
+    FP_TYPE* c_frame = fetch_frame(x, nx, ihop * param.a_nhop, param.a_nhop * 2);
+    for(int i = 0; i < param.a_nhop * 2; ++ i) {
+      s_range[i] = i - param.a_nhop;
+      c_frame[i] *= s_window[i];
+    }
+
+    // do iterations
+    FP_TYPE lastsrer = -INFINITY;
+    for(int iiter = 0; iiter < param.a_maxairiter; ++ iiter) {
+      // analysis
+      int nhar = param.a_mvf / f0[ihop];
+      int winlen = (int)(((FP_TYPE)fs) / f0[ihop] * window_periods) * 2 + 1;
+      FP_TYPE* a_window = window_func(winlen);
+      FP_TYPE* a_frame = fetch_frame(x, nx, ihop * param.a_nhop, winlen);
+      qhm_solve_status *status = qhm_status_init(a_frame, a_window, f0[ihop], param.a_maxqhmcorr, winlen, fs, nhar);
+      int info = qhm_iter(status);
+      if(info != 0) abort(); // error occurred
+
+      // synthesis and calculate srer
+      double complex* s_work = calloc(sizeof(double complex), (status->K + 1) * param.a_nhop * 2);
+      qhm_synth(status->lstsqb, status->fk_hat, s_range, s_frame, status->K, param.a_nhop * 2, fs, s_work);
+      for(int i = 0; i < param.a_nhop * 2; ++ i)
+        s_frame[i] *= s_window[i];
+      FP_TYPE currsrer = qhm_calc_srer(c_frame, s_frame, param.a_nhop * 2, srer_work);
+
+      // update f0
+      if(currsrer > lastsrer) {
+        int nmean = nhar / 3 > 16 ? 16 : nhar / 3;
+        FP_TYPE meanf0 = 0.0;
+        for(int i = 0; i < nmean; ++ i)
+          meanf0 += status->fk_hat[nhar + 1 + i] / (i + 1);
+        meanf0 /= nmean;
+        f0[ihop] = meanf0;
+      }
+
+      // check whether stop iteration
+      if(currsrer - lastsrer < 0.1) {
+        if(currsrer > lastsrer)
+          lastsrer = currsrer;
+        free(s_work);
+        qhm_status_free(status);
+        free(a_frame);
+        free(a_window);
+        break;
+      }
+
+      if(currsrer > lastsrer)
+        lastsrer = currsrer;
+
+      free(s_work);
+      qhm_status_free(status);
+      free(a_frame);
+      free(a_window);
+    }
+    printf("  SRER: %lf\n", lastsrer);
+    free(c_frame);
+  }
+
+  free(srer_work);
+  free(s_range);
+  free(s_frame);
+  free(s_window);
+}
+
+void qhm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int nhop, llsm_sinparam* sinu, const char* wtype) {
+  double window_periods = 2.5;
+  window_getter window_func;
+  if(! strcmp(wtype, "blackman_harris")) {
+    window_func = blackman_harris;
+    window_periods = 2.2;
+  }
+  else if(! strcmp(wtype, "hamming")) {
+    window_func = hamming;
+    window_periods = 1.5;
+  }
+  else if(! strcmp(wtype, "hanning")) {
+    window_func = hanning;
+    window_periods = 1.5;
+  }
+  else if(! strcmp(wtype, "blackman")) {
+    window_func = blackman;
+    window_periods = 1.65;
+  }
+  else {
+    fprintf(stderr, "Unknown window type %s. Aborting...", wtype);
+    abort();
+  }
+
+  FP_TYPE* s_window = hanning(param.a_nhop * 2);
+  FP_TYPE* s_frame = calloc(sizeof(FP_TYPE), param.a_nhop * 2);
+  FP_TYPE* s_range = calloc(sizeof(FP_TYPE), param.a_nhop * 2);
+  FP_TYPE* srer_work = calloc(sizeof(FP_TYPE), param.a_nhop * 2);
+
+  for(int ihop = 0; ihop < nhop; ++ ihop) {
+    if(f0[ihop] <= 0.0) continue;
+    printf("QHM: %d / %d\n", ihop, nhop);
+
+    // get comparison frame and analysis frame
+    FP_TYPE* c_frame = fetch_frame(x, nx, ihop * param.a_nhop, param.a_nhop * 2);
+    for(int i = 0; i < param.a_nhop * 2; ++ i) {
+      s_range[i] = i - param.a_nhop;
+      c_frame[i] *= s_window[i];
+    }
+
+    int nhar = param.a_mvf / f0[ihop];
+    int winlen = (int)(((FP_TYPE)fs) / f0[ihop] * window_periods) * 2 + 1;
+    FP_TYPE* a_window = window_func(winlen);
+    FP_TYPE* a_frame = fetch_frame(x, nx, ihop * param.a_nhop, winlen);
+    qhm_solve_status *status = qhm_status_init(a_frame, a_window, f0[ihop], param.a_maxqhmcorr, winlen, fs, nhar);
+    FP_TYPE bestsrer = -INFINITY;
+    double complex* bestak = calloc(sizeof(double complex), status->K);
+    FP_TYPE* bestfk_hat = calloc(sizeof(FP_TYPE), status->K);
+
+    // iteration
+    for(int iiter = 0; iiter < param.a_maxqhmiter; ++ iiter) {
+      // analysis
+      int info = qhm_iter(status);
+      if(info != 0) abort(); // error occurred
+
+      // synthesis and calculate srer
+      qhm_synth_half(status->lstsqb, status->fk_hat, s_range, s_frame, status->K, param.a_nhop * 2, fs);
+      for(int i = 0; i < param.a_nhop * 2; ++ i)
+        s_frame[i] *= s_window[i];
+      FP_TYPE currsrer = qhm_calc_srer(c_frame, s_frame, param.a_nhop * 2, srer_work);
+      // check whether update bestak
+      if(currsrer > bestsrer) {
+        bestsrer = currsrer;
+        memcpy(bestfk_hat, status->fk_hat, status->K * sizeof(FP_TYPE));
+        memcpy(bestak, status->lstsqb, status->K * sizeof(double complex));
+      }
+    }
+
+    // export sinusoidal parameters
+    if(isinf(bestsrer) || isnan(bestsrer)) {
+      fprintf(stderr, "QHM: Failed to analyze at %d. Aborting...\n", ihop);
+      abort();
+    }
+    qhm_harmonic_parameter_from_ak(bestak, bestfk_hat, status->K, param.a_nhar, sinu -> freq[ihop], sinu -> ampl[ihop], sinu -> phse[ihop]);
+    printf("  SRER: %lf\n", bestsrer);
+
+    free(bestfk_hat);
+    free(bestak);
+    qhm_status_free(status);
+    free(a_frame);
+    free(a_window);
+    free(c_frame);
+  }
+
+  free(srer_work);
+  free(s_frame);
+  free(s_range);
+  free(s_window);
+}
+
+qhm_solve_status* qhm_status_init(FP_TYPE* x, FP_TYPE* window, FP_TYPE f0, FP_TYPE maxcorr, int nx, int fs, int nhar) {
+  qhm_solve_status *status = calloc(sizeof(qhm_solve_status), 1);
+
+  status->x = x;
+  status->window = window;
+  status->f0 = f0;
+  status->maxcorr = maxcorr;
+  status->nx = nx;
+  status->fs = fs;
+  status->nhar = nhar;
+
+  status->K = status->nhar * 2 + 1;
+  status->N = (status->nx - 1) / 2;
+  status->fk_hat = calloc(sizeof(FP_TYPE), status->K);
+  status->n = calloc(sizeof(FP_TYPE), nx);
+  status->t = calloc(sizeof(FP_TYPE), status->K * nx);
+  status->Ea = calloc(sizeof(double complex), 2 * status->K * nx);
+  status->Ew = calloc(sizeof(double complex), nx * 2 * status->K);
+  status->R = calloc(sizeof(double complex), 2 * status->K * 2 * status->K);
+  status->windowed_x = calloc(sizeof(double complex), nx);
+  status->lstsqb = calloc(sizeof(double complex), 2 * status->K);
+
+  qhm_status_reset(status);
+
+  return status;
+}
+
+void qhm_status_reset(qhm_solve_status* status) {
+  for(int i = -status->nhar; i < status->nhar + 1; ++ i)
+    status->fk_hat[i + status->nhar] = ((FP_TYPE)i) * status->f0;
+  for(int i = -status->N; i < status->N + 1; ++ i)
+    status->n[i + status->N] = (FP_TYPE)i;
+}
+
+void qhm_status_free(qhm_solve_status* status) {
+  free(status->fk_hat);
+  free(status->n);
+  free(status->t);
+  free(status->Ea);
+  free(status->Ew);
+  free(status->R);
+  free(status->windowed_x);
+  free(status->lstsqb);
+
+  free(status);
+}
+
+int qhm_iter(qhm_solve_status* status) {
+  int m, n, k;
+  /* LS Analysis */
+  // t = np.dot(2 * np.pi * fk_hat, n) / sr
+  for(int row = 0; row < status->K; ++ row) {
+    double a = 2.0 * M_PI * status->fk_hat[row] / (FP_TYPE)status->fs;
+    for(int col = 0; col < status->nx; ++col)
+      status->t[row * status->nx + col] = a * status->n[col];
+  }
+
+  // E = np.cos(t) + 1j * np.sin(t), mat with cplx exp
+  // Ea = np.concatenate((E, np.tile(n, (K, 1)) * E), axis = 0)
+  int base = status->K * status->nx;
+  for(int i = 0; i < base; ++ i)
+    status->Ea[i] = cos(status->t[i]) + sin(status->t[i]) * I;
+  for(int i = 0; i < base; ++ i)
+    status->Ea[i + base] = status->Ea[i] * status->n[i % status->nx];
+  // Ew = np.tile(window, (1, 2 * K)) * Ea.T # multiply the window
+  for(int row = 0; row < status->nx; ++ row)
+    for(int col = 0; col < 2 * status->K; ++col)
+      status->Ew[row * 2 * status->K + col] = status->window[row] * status->Ea[col * status->nx + row];
+
+  // R = np.dot(Ew.T, Ew), compute the matrix to be inverted
+  m = 2 * status->K;
+  n = 2 * status->K;
+  k = status->nx;
+  double complex alpha = 1.0, beta = 0.0;
+  cblas_zgemm(CblasRowMajor, CblasTrans, CblasNoTrans,
+    m, n, k, &alpha,
+    status->Ew, m,
+    status->Ew, n,
+    &beta, status->R, n
+  );
+  // lstsqb = np.dot(Ew.T, x * window)
+  for(int i = 0; i < status->nx; ++ i)
+    status->windowed_x[i] = status->x[i] * status->window[i];
+  m = 2 * status->K;
+  n = 1;
+  k = status->nx;
+  cblas_zgemm(CblasRowMajor, CblasTrans, CblasNoTrans,
+    m, n, k, &alpha,
+    status->Ew, m,
+    status->windowed_x, n,
+    &beta, status->lstsqb, n
+  );
+
+  // theta = sla.lstsq(R, lstsqb)[0]
+  int rank;
+  m = 2 * status->K;
+  n = 2 * status->K;
+  int nrhs = 1;
+  double s[2 * status->K];
+  int info = LAPACKE_zgelsd(LAPACK_ROW_MAJOR, m, n, nrhs, status->R, n, status->lstsqb, nrhs, s, -1.0, &rank);
+  if(info > 0) {
+    fprintf(stderr, "SVD failed to converge.\n");
+    return info;
+  }
+  else if(info < 0) {
+    fprintf(stderr, "Wrong parameter.\n");
+    abort();
+  }
+
+  // corr
+  // fk_hat += np.clip(sr / (2 * np.pi) * (ak.real * bk.imag - ak.imag * bk.real) / (np.abs(ak) ** 2), -maxCorr, maxCorr)
+  base = status->K;
+  for(int i = 0; i < status->K; ++i) {
+    double absak = cabs(status->lstsqb[i]);
+    double delta = status->fs / (2.0 * M_PI) * (creal(status->lstsqb[i]) * cimag(status->lstsqb[base + i]) - cimag(status->lstsqb[i]) * creal(status->lstsqb[base + i])) / (absak * absak);
+    if(delta > status->maxcorr) delta = status->maxcorr;
+    else if(delta < -status->maxcorr) delta = -status->maxcorr;
+    status->fk_hat[i] += delta;
+  }
+
+  return 0;
+}
+
+void qhm_synth(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE* out, int K, int nout, int fs, double complex* work) {
+  int needfree = 0;
+  if(work == NULL) {
+    work = calloc(sizeof(double complex*), (K + 1) * nout);
+    needfree = 1;
+  }
+
+  double complex* dotb = work; // (K, nout)
+  double complex* outtemp = work + (K * nout); // (nout)
+
+  // dotb = np.exp(np.dot(2j * np.pi * fk_hat, r) / sr)
+  for(int row = 0; row < K; ++ row) {
+    double complex a = (2 * M_PI * fk_hat[row]) * I;
+    for(int col = 0; col < nout; ++ col)
+      dotb[row * nout + col] = cexp(a * synthrange[col] / ((double complex)fs));
+  }
+
+  // out = np.dot(ak.T, work).real
+  int m, n, k;
+  m = 1;
+  n = nout;
+  k = K;
+  double complex alpha = 1.0, beta = 0.0;
+  cblas_zgemm(CblasRowMajor, CblasTrans, CblasNoTrans,
+    m, n, k, &alpha,
+    ak, m,
+    dotb, n,
+    &beta, outtemp, n
+  );
+
+  for(int i = 0; i < nout; ++i)
+    out[i] = creal(outtemp[i]);
+
+  if(needfree) free(work);
+}
+
+FP_TYPE qhm_stdev(FP_TYPE* x, int n) {
+  FP_TYPE mean = sumfp(x, n) / n;
+  FP_TYPE sum_deviation = 0.0;
+  for(int i = 0; i < n; ++ i)
+    sum_deviation += (x[i] - mean) * (x[i] - mean);
+  return sqrt(sum_deviation / n);
+}
+
+FP_TYPE qhm_calc_srer(FP_TYPE* x, FP_TYPE* y, int n, FP_TYPE* work) {
+  int needfree = 0;
+  if(work == NULL) {
+    work = calloc(sizeof(FP_TYPE), n);
+    needfree = 1;
+  }
+
+  for(int i = 0; i < n; ++ i)
+    work[i] = x[i] - y[i];
+
+  FP_TYPE orig_stdev = qhm_stdev(x, n);
+  FP_TYPE delta_stdev = qhm_stdev(work, n);
+
+  if(needfree) free(work);
+
+  return log10(orig_stdev / delta_stdev) * 20.0;
+}
+
+void qhm_synth_half(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE* out, int K, int nout, int fs) {
+  int nhar = (K - 1) / 2;
+  for(int i = 0; i < nout; ++ i)
+    out[i] = 0.0;
+  for(int ihar = 0; ihar < nhar; ++ ihar) {
+    double freq = fk_hat[nhar + 1 + ihar];
+    double ampl = cabs(ak[nhar + 1 + ihar]) * 2.0;
+    double phse = carg(ak[nhar + 1 + ihar]);
+    double fph = 2.0 * M_PI / ((double)fs) * freq;
+    for(int i = 0; i < nout; ++ i)
+      out[i] += cos(fph * ((double)synthrange[i]) + phse) * ampl;
+  }
+}
+
+void qhm_harmonic_parameter_from_ak(double complex* ak, FP_TYPE* fk_hat, int K, int nhar, FP_TYPE* freq, FP_TYPE* ampl, FP_TYPE* phse)
+{
+  int akhar = (K - 1) / 2;
+  int outhar = akhar < nhar ? akhar : nhar;
+
+  for(int i = 0; i < outhar; ++i) {
+    freq[i] = fk_hat[akhar + 1 + i];
+    ampl[i] = cabs(ak[akhar + 1 + i]) * 2.0;
+    phse[i] = carg(ak[akhar + 1 + i]);
+  }
+
+  FP_TYPE* phse_ = unwrap(phse, outhar);
+  for(int i = 0; i < outhar; ++i)
+    phse[i] = phse_[i];
+  free(phse_);
+}

--- a/qhm.h
+++ b/qhm.h
@@ -94,10 +94,6 @@ void qhm_synth(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE
 void qhm_synth_half(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE* out,
   int K, int nout, int fs);
 
-FP_TYPE qhm_stdev(FP_TYPE* x, int n);
-// work.shape == (n)
-FP_TYPE qhm_calc_srer(FP_TYPE* x, FP_TYPE* y, int n, FP_TYPE* work);
-
 void qhm_harmonic_parameter_from_ak(double complex* ak, FP_TYPE* fk_hat, int K, int nhar,
   FP_TYPE* freq, FP_TYPE* ampl, FP_TYPE* phse);
 

--- a/qhm.h
+++ b/qhm.h
@@ -56,15 +56,32 @@ typedef struct {
 
 } qhm_solve_status;
 
+/*
+* Switch of progress output, 1 by default.
+*/
 void qhm_progress(int v);
+
+/*
+* Least-Square F0 Adaptive Iteration Refinement(AIR)
+*/
 void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int nhop, const char* wtype);
+
+/*
+* Least-Square Sinusoid parameter iteration anaysis.
+*/
 void qhm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int nhop, llsm_sinparam* sinu, const char* wtype);
 
+/*
+* QHM iterator functions
+*/
 qhm_solve_status* qhm_status_init(FP_TYPE* x, FP_TYPE* window, FP_TYPE f0, FP_TYPE maxcorr, int nx, int fs, int nhar, char lsmethod);
 void qhm_status_reset(qhm_solve_status* status);
 void qhm_status_free(qhm_solve_status* status);
 int qhm_iter(qhm_solve_status* status);
 
+/*
+* QHM result analysis functions.
+*/
 // work.size == K + 1 * nout
 void qhm_synth(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE* out, int K, int nout, int fs, double complex* work);
 void qhm_synth_half(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE* out, int K, int nout, int fs);

--- a/qhm.h
+++ b/qhm.h
@@ -56,6 +56,7 @@ typedef struct {
 
 } qhm_solve_status;
 
+void qhm_progress(int v);
 void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int nhop, const char* wtype);
 void qhm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int nhop, llsm_sinparam* sinu, const char* wtype);
 

--- a/qhm.h
+++ b/qhm.h
@@ -41,6 +41,7 @@ typedef struct {
   FP_TYPE f0;
   FP_TYPE maxcorr; // max correction per step (in Hz)
   int nx, fs, nhar;
+  char ls_method;
 
   // run status
   int K, N; // (nHar * 2 + 1), (nX - 1) / 2
@@ -58,7 +59,7 @@ typedef struct {
 void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int nhop, const char* wtype);
 void qhm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int nhop, llsm_sinparam* sinu, const char* wtype);
 
-qhm_solve_status* qhm_status_init(FP_TYPE* x, FP_TYPE* window, FP_TYPE f0, FP_TYPE maxcorr, int nx, int fs, int nhar);
+qhm_solve_status* qhm_status_init(FP_TYPE* x, FP_TYPE* window, FP_TYPE f0, FP_TYPE maxcorr, int nx, int fs, int nhar, char lsmethod);
 void qhm_status_reset(qhm_solve_status* status);
 void qhm_status_free(qhm_solve_status* status);
 int qhm_iter(qhm_solve_status* status);

--- a/qhm.h
+++ b/qhm.h
@@ -1,0 +1,76 @@
+/*
+qhm.h - Quasi-Harmonic Model with Adaptive Iterative Refinement
+===
+Copyright (c) 2016 tuxzz. All rights reserved.
+Developed by: tuxzz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+    Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimers.
+    Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimers in the documentation
+and/or other materials provided with the distribution.
+    Neither the names of development group, institution, nor the names of its
+contributors may be used to endorse or promote products derived from this
+Software without specific prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE CONTRIBUTORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
+*/
+
+#ifndef QHM
+#define QHM
+
+#include "llsm.h"
+#include "complex.h"
+
+typedef struct {
+  FP_TYPE* x; // original signal. shape = (nX, 1)
+  FP_TYPE* window; // shape = (nX, 1)
+
+  FP_TYPE f0;
+  FP_TYPE maxcorr; // max correction per step (in Hz)
+  int nx, fs, nhar;
+
+  // run status
+  int K, N; // (nHar * 2 + 1), (nX - 1) / 2
+  FP_TYPE* fk_hat; // freq. of harmonics. (K, 1)
+  FP_TYPE* n; // time vec. (1, nX)
+  FP_TYPE* t; // arg of cplx exp, (K, 2N + 1)
+  double complex* Ea; // matrix with cplx exp, (2K, 2N + 1)
+  double complex* Ew; // E multiply the window, (2N + 1, 2K)
+  double complex* R; // E multiply the window, (2K, 2K);
+  double complex* windowed_x; // (nX, 1)
+  double complex* lstsqb; // (2 * K, 1), contains ak and bk(outputs)
+
+} qhm_solve_status;
+
+void qhm_air(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int nhop, const char* wtype);
+void qhm_analyze(llsm_parameters param, FP_TYPE* x, int nx, int fs, FP_TYPE* f0, int nhop, llsm_sinparam* sinu, const char* wtype);
+
+qhm_solve_status* qhm_status_init(FP_TYPE* x, FP_TYPE* window, FP_TYPE f0, FP_TYPE maxcorr, int nx, int fs, int nhar);
+void qhm_status_reset(qhm_solve_status* status);
+void qhm_status_free(qhm_solve_status* status);
+int qhm_iter(qhm_solve_status* status);
+
+// work.size == K + 1 * nout
+void qhm_synth(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE* out, int K, int nout, int fs, double complex* work);
+void qhm_synth_half(double complex* ak, FP_TYPE* fk_hat, FP_TYPE* synthrange, FP_TYPE* out, int K, int nout, int fs);
+
+FP_TYPE qhm_stdev(FP_TYPE* x, int n);
+// work.shape == (n)
+FP_TYPE qhm_calc_srer(FP_TYPE* x, FP_TYPE* y, int n, FP_TYPE* work);
+
+void qhm_harmonic_parameter_from_ak(double complex* ak, FP_TYPE* fk_hat, int K, int nhar, FP_TYPE* freq, FP_TYPE* ampl, FP_TYPE* phse);
+
+#endif // QHM

--- a/readme.md
+++ b/readme.md
@@ -19,8 +19,7 @@ License: [UIUC license](https://en.wikipedia.org/wiki/University_of_Illinois/NCS
 
 Requirement
 ---
-A CBLAS and a LAPACKE.
-Tested on reference blas/lapack and OpenBLAS.
+A CBLAS-compatible and a LAPACKE-compatible library.
 
 Acknowledgement
 ---
@@ -40,6 +39,6 @@ Works cited
 
 * Stylianou, Yannis. "Harmonic plus noise models for speech, combined with statistical methods, for speech and speaker modification." Diss. Ecole Nationale Supérieure des Télécommunications. 1996.
 
-* Pantazis Y, Rosec O, Stylianou Y. Iterative estimation of sinusoidal signal parameters[J]. Signal Processing Letters, IEEE, 2010, 17(5): 461-464.
+* Pantazis, Yannis, Olivier Rosec, and Yannis Stylianou. "Iterative estimation of sinusoidal signal parameters." IEEE Signal Processing Letters 17.5 (2010): 461-464.
 
-* Degottex G, Stylianou Y. Analysis and synthesis of speech using an adaptive full-band harmonic model[J]. Audio, Speech, and Language Processing, IEEE Transactions on, 2013, 21(10): 2085-2095.
+* Degottex, Gilles, and Yannis Stylianou. "Analysis and synthesis of speech using an adaptive full-band harmonic model." IEEE Transactions on Audio, Speech, and Language Processing 21.10 (2013): 2085-2095.

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,11 @@ It is designed to be an **interpolatable**, **low-level** speech representation 
 
 License: [UIUC license](https://en.wikipedia.org/wiki/University_of_Illinois/NCSA_Open_Source_License)
 
+Requirement
+---
+A CBLAS and a LAPACKE.
+Tested on reference blas/lapack and OpenBLAS.
+
 Acknowledgement
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -35,3 +35,6 @@ Works cited
 
 * Stylianou, Yannis. "Harmonic plus noise models for speech, combined with statistical methods, for speech and speaker modification." Diss. Ecole Nationale Supérieure des Télécommunications. 1996.
 
+* Pantazis Y, Rosec O, Stylianou Y. Iterative estimation of sinusoidal signal parameters[J]. Signal Processing Letters, IEEE, 2010, 17(5): 461-464.
+
+* Degottex G, Stylianou Y. Analysis and synthesis of speech using an adaptive full-band harmonic model[J]. Audio, Speech, and Language Processing, IEEE Transactions on, 2013, 21(10): 2085-2095.

--- a/test/test.c
+++ b/test/test.c
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
   //lparam.a_nnos = 128;
   lparam.a_nosf = 16000;
   lparam.a_nhop = pow(2, ceil(log2(fs * 0.005)));
-  lparam.a_method = qhm;
+  lparam.a_hamethod = LLSM_HAMETHOD_QHM;
   qhm_progress(1);
   printf("Analyzing...\n");
   llsm* model = llsm_analyze(lparam, x, nx, fs, f0, nfrm);

--- a/test/test.c
+++ b/test/test.c
@@ -79,6 +79,7 @@ int main(int argc, char** argv) {
   //lparam.a_nnos = 128;
   lparam.a_nosf = 16000;
   lparam.a_nhop = pow(2, ceil(log2(fs * 0.005)));
+  lparam.a_method = qhm;
   qhm_progress(1);
   printf("Analyzing...\n");
   llsm* model = llsm_analyze(lparam, x, nx, fs, f0, nfrm);

--- a/test/test.c
+++ b/test/test.c
@@ -37,6 +37,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE SOFTWARE.
 #include "../external/libpyin/pyin.h"
 #include "../math-funcs.h"
 #include "../llsm.h"
+#include "../qhm.h"
 
 double get_time() {
   struct timeval t;
@@ -49,7 +50,7 @@ int main(int argc, char** argv) {
     fprintf(stderr, "Missing argument.\n");
     return 1;
   }
-  
+
   int fs = 0;
   int nbit = 0;
   int nx = 0;
@@ -66,7 +67,7 @@ int main(int argc, char** argv) {
   param.trange = 24;
   param.nf = ceil(fs * 0.025);
   param.w = param.nf / 4;
-  
+
   int nfrm = 0;
   double* f0 = pyin_analyze(param, x, nx, fs, & nfrm);
 
@@ -78,18 +79,19 @@ int main(int argc, char** argv) {
   //lparam.a_nnos = 128;
   lparam.a_nosf = 16000;
   lparam.a_nhop = pow(2, ceil(log2(fs * 0.005)));
+  qhm_progress(1);
   printf("Analyzing...\n");
   llsm* model = llsm_analyze(lparam, x, nx, fs, f0, nfrm);
 
   lparam.s_fs = fs;
-  
+
   printf("Synthesizing...\n");
   double t0 = get_time();
   int ny;
   double* y = llsm_synthesize(lparam, model, & ny);
   double tspent = get_time() - t0;
   printf("%f ms, %fs/s\n", tspent, (double)nx / fs / tspent * 1000);
-  
+
   wavwrite(y, ny, lparam.s_fs, 16, "resynth.wav");
 
   llsm_deinit(lparam);
@@ -100,4 +102,3 @@ int main(int argc, char** argv) {
 
   return 0;
 }
-

--- a/test/test.c
+++ b/test/test.c
@@ -79,8 +79,11 @@ int main(int argc, char** argv) {
   //lparam.a_nnos = 128;
   lparam.a_nosf = 16000;
   lparam.a_nhop = pow(2, ceil(log2(fs * 0.005)));
-  lparam.a_hamethod = LLSM_HAMETHOD_QHM;
-  qhm_progress(1);
+  if(is_hamethod_supported(LLSM_HAMETHOD_QHM)) {
+    lparam.a_hamethod = LLSM_HAMETHOD_QHM;
+    qhm_progress(1);
+  } else
+    lparam.a_hamethod = LLSM_HAMETHOD_QFFT;
   printf("Analyzing...\n");
   llsm* model = llsm_analyze(lparam, x, nx, fs, f0, nfrm);
 


### PR DESCRIPTION
## Changes
1. Add Least-Square harmonic analysis method. (qhm.c and qhm.h, need 3rd-party lib, see below)
2. Update libpyin to the latest version.
3. Fix inline functions.
## About QHM-AIR
### Requirements
- CBLAS for zgemm
- LAPACKE for zgels and zgelsd

Tested on OpenBLAS and reference blas/lapack
### Advantage

Obviously quality improving compared to FFT Peak picking.
By looking: http://img.vim-cn.com/4a/2a8b0a135ed0e0fd35ad0327570ba29922a23b.png
By listening: https://mega.nz/#!60MVwTxY!01Vy9k-50-BqpWPqMcUOIUv0iRTTTSj6fRjTa2zLTIk
Voice source: Gakkou Gurashi
### Disadvantage

Slower than fft peak picking. Especially on using zgelsd method for LS.
### Works Cited
- Pantazis Y, Rosec O, Stylianou Y. Iterative estimation of sinusoidal signal parameters[J]. Signal Processing Letters, IEEE, 2010, 17(5): 461-464.
- Degottex G, Stylianou Y. Analysis and synthesis of speech using an adaptive full-band harmonic model[J]. Audio, Speech, and Language Processing, IEEE Transactions on, 2013, 21(10): 2085-2095.

**I hope future version of morsampler can have QHM-AIR as an optional harmonic analysis method.**
